### PR TITLE
Increase maxBuffer to prevent fc-list output overflow error.

### DIFF
--- a/libs/linux/index.js
+++ b/libs/linux/index.js
@@ -19,7 +19,7 @@ module.exports = async () => {
     ? 'fc-list'
     : 'fc-list2'
 
-  let r = await pexec(fcListBinary)
+  let r = await pexec(fcListBinary, {maxBuffer: 1024*1024*10})
   let lines = r.stdout.split('\n')
   lines = lines
     .map(ln => ln.split(':')[1])


### PR DESCRIPTION
On my Debian desktop, fc-list is quite verbose and produces 464KB of output, which caused a buffer overflow error.  This commit would raise that limit to 10MB.  Some people have lots of fonts installed.  I'm not sure if this kind of overflow is potentially an issue on other platforms.

Anyway, thanks very much for creating this package!  It's just what I needed.  Nice and simple and easy to deploy.