### PR TITLE
Only require once since we know the other two requires won't be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,22 @@
 
 'use strict'
 
-const for_darwin = require('./libs/darwin')
-const for_win32 = require('./libs/win32')
-const for_linux = require('./libs/linux')
-
 const platform = process.platform
+
+let getFontsFunc
+switch(platform) {
+  case 'darwin':
+    getFontsFunc = require('./libs/darwin')
+    break;
+  case 'win32':
+    getFontsFunc = require('./libs/win32')
+    break;
+  case 'linux':
+    getFontsFunc = require('./libs/linux');
+    break;
+  default:
+    throw new Error(`Error: font-list can not run on ${platform}.`)
+}
 
 const defaultOptions = {
   disableQuoting: false
@@ -18,20 +29,7 @@ const defaultOptions = {
 exports.getFonts = async (options) => {
   options = Object.assign({}, defaultOptions, options)
 
-  let fonts
-
-  if (platform === 'darwin') {
-    fonts = await for_darwin()
-
-  } else if (platform === 'win32') {
-    fonts = await for_win32()
-
-  } else if (platform === 'linux') {
-    fonts = await for_linux()
-
-  } else {
-    throw new Error(`Error: font-list can not run on ${platform}.`)
-  }
+  let fonts = await getFontsFunc();
 
   fonts = fonts.map(i => {
     // parse unicode names, eg: '"\\U559c\\U9e4a\\U805a\\U73cd\\U4f53"' -> '"喜鹊聚珍体"'


### PR DESCRIPTION
Since we know that only one platform will be used (darwin, win32, or linux), we know that two of the requires won't be used. (i.e. if the platform were linux for_darwin and for_win32 wouldn't be used)

Tested only on Windows 10 but it should work in theory.