### PR TITLE
修复获取的字体CSS无法使用的问题

### DIFF
--- a/libs/win32/getByPowerShell.js
+++ b/libs/win32/getByPowerShell.js
@@ -9,7 +9,7 @@ const exec = require('child_process').exec
 const parse = (str) => {
   let fonts = []
   str.split('\n').map(ln => fonts.push(ln.trim()))
-  return fonts
+  return fonts.filter(f => !!f && !f.includes(':'))
 }
 
 /*
@@ -19,7 +19,7 @@ const parse = (str) => {
   (New-Object System.Drawing.Text.InstalledFontCollection).Families
 */
 module.exports = () => new Promise((resolve, reject) => {
-  let cmd = `powershell -command "Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
+  let cmd = `powershell -command "chcp 65001;Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
 
   exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, stderr) => {
     if (err) {

--- a/libs/win32/getByPowerShell.js
+++ b/libs/win32/getByPowerShell.js
@@ -8,16 +8,7 @@ const exec = require('child_process').exec
 
 const parse = (str) => {
   let fonts = []
-  str.split('\n').map(ln => {
-    ln = ln.trim()
-    if (!ln || !ln.includes(':')) return
-
-    ln = ln.split(':')
-    if (ln.length !== 2 || ln[0].trim() !== 'Name') return
-
-    fonts.push(ln[1].trim())
-  })
-
+  str.split('\n').map(ln => fonts.push(ln.trim()))
   return fonts
 }
 
@@ -28,7 +19,7 @@ const parse = (str) => {
   (New-Object System.Drawing.Text.InstalledFontCollection).Families
 */
 module.exports = () => new Promise((resolve, reject) => {
-  let cmd = `powershell -command "chcp 65001;[System.Reflection.Assembly]::LoadWithPartialName('System.Drawing');(New-Object System.Drawing.Text.InstalledFontCollection).Families"`
+  let cmd = `powershell -command "Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
 
   exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, stderr) => {
     if (err) {


### PR DESCRIPTION
目前仅修改Windows下PowerShell的获取，vbs和其他环境没有修改
并且字体默认优先获取中文名称