### PR TITLE
Properly get fonts that have `:` in its name by PowerShell.

### DIFF
--- a/libs/win32/getByPowerShell.js
+++ b/libs/win32/getByPowerShell.js
@@ -10,19 +10,27 @@ const parse = (str) => {
   return str
     .split('\n')
     .map(ln => ln.trim())
-    .filter(f => f && !f.includes(':'))
+    .filter(f => !!f)
 }
 
 /*
 @see https://superuser.com/questions/760627/how-to-list-installed-font-families
 
-  [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing")
-  (New-Object System.Drawing.Text.InstalledFontCollection).Families
+  chcp 65001 | Out-Null
+  Add-Type -AssemblyName PresentationCore
+  $families = [Windows.Media.Fonts]::SystemFontFamilies
+  foreach ($family in $families) {
+    $name = ''
+    if (!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'), [ref]$name)) {
+      $name = $family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]
+    }
+    echo $name
+  }
 */
 module.exports = () => new Promise((resolve, reject) => {
-  let cmd = `powershell -command "chcp 65001;Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
+  let cmd = `powershell -command "chcp 65001|Out-Null;Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
 
-  exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (err, stdout, stderr) => {
+  exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (err, stdout) => {
     if (err) {
       reject(err)
       return


### PR DESCRIPTION
- Use ` | Out-Null` to avoid `Active code page: 65001` message showing
- Update comments to match the command
- Remove unused variable `stderr` in `exec()` callback function

Closes #23