### PR TITLE
Properly display the name of font that contains `:` on Linux.

### DIFF
--- a/libs/linux/index.js
+++ b/libs/linux/index.js
@@ -19,13 +19,10 @@ module.exports = async () => {
     ? 'fc-list'
     : 'fc-list2'
 
-  let r = await pexec(fcListBinary, { maxBuffer: 1024 * 1024 * 10 })
-  let lines = r.stdout.split('\n')
-  lines = lines
-    .map(ln => ln.split(':')[1])
-    .filter(i => i)
-    .map(i => i.split(',')[0].trim())
-    .filter(i => i)
+  const cmd = fcListBinary + ' -f "%{family[0]}\\n"'
 
-  return Array.from(new Set(lines))
+  const { stdout } = await pexec(cmd, { maxBuffer: 1024 * 1024 * 10 })
+  const fonts = stdout.split('\n').filter(f => !!f)
+
+  return Array.from(new Set(fonts))
 }


### PR DESCRIPTION
Closes #26

- Use `-f "%{family[0]}\n"` option of `fc-list` command to directly get the font family name