### PR TITLE
修复中文乱码问题

### DIFF
--- a/libs/win32/getByPowerShell.js
+++ b/libs/win32/getByPowerShell.js
@@ -28,7 +28,7 @@ const parse = (str) => {
   }
 */
 module.exports = () => new Promise((resolve, reject) => {
-  let cmd = `powershell -command "chcp 65001|Out-Null;Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
+  let cmd = `chcp 65001|powershell -command "chcp 65001|Out-Null;Add-Type -AssemblyName PresentationCore;$families=[Windows.Media.Fonts]::SystemFontFamilies;foreach($family in $families){$name='';if(!$family.FamilyNames.TryGetValue([Windows.Markup.XmlLanguage]::GetLanguage('zh-cn'),[ref]$name)){$name=$family.FamilyNames[[Windows.Markup.XmlLanguage]::GetLanguage('en-us')]}echo $name}"`
 
   exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (err, stdout) => {
     if (err) {


### PR DESCRIPTION
内层执行chcp后只是powershell的输出为u8，但外层node执行exec时等价于调用了cmd，需要把cmd环境下编码也更改一次，否则输出也可能会乱码
已在electron下测试通过