### PR TITLE
fix: missing type declarations in ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./index.d.ts"
     }
   },
   "types": "index.d.ts",


### PR DESCRIPTION
Added the `types` field to exports to fix an issue where the type declarations could not be loaded when the importing package is of `"type":"module"`

Related error message:
```
Could not find a declaration file for module 'font-list'. '~/src/font-list-fix/node_modules/font-list/index.mjs' implicitly has an 'any' type.
  There are types at '~/src/font-list-fix/node_modules/font-list/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'font-list' library may need to update its package.json or typings.
```

After this change the error goes away and the imports work as expected. Included tests pass on Linux.